### PR TITLE
feat: add codex as an extension dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "BiblioNexus Foundation"
   },
-  "version": "0.0.19",
+  "version": "0.0.20",
   "publisher": "project-accelerate",
   "homepage": "https://codex-editor.gitbook.io/",
   "license": "MIT",


### PR DESCRIPTION
Adds codex-editor-extension as a dependency so we can have only one extension that doesn't get automatically updated in codex. 

Codex-editor also has 'shared-state-store' and 'scripture-language-support' as dependencies which also get installed with this. 